### PR TITLE
Adding SNI and remote host validation

### DIFF
--- a/src/services/iot/cloud/cloud_service.c
+++ b/src/services/iot/cloud/cloud_service.c
@@ -260,8 +260,7 @@ static int8_t connectMQTTSocket(void)
              ret = BSD_setsockopt(*context->tcpClientSocket, SOL_SSL_SOCKET, SO_SSL_ENABLE_SNI_VALIDATION, &optVal, sizeof(optVal));
          }
 
-         if (ret == BSD_SUCCESS)
-         {
+         if (ret == BSD_SUCCESS) {
              debug_print("CLOUD: Connect socket");
              ret = BSD_connect(*context->tcpClientSocket, (struct bsd_sockaddr*) & addr, sizeof (struct bsd_sockaddr_in));
          }


### PR DESCRIPTION
Using SNI activates remote certificate validation as well:

```C
#define SO_SSL_ENABLE_SNI_VALIDATION                        0x04
/*!<
    Enable SNI validation against the server's certificate subject
    common name. If there is no SNI provided (via the SO_SSL_SNI 
    option), setting this option does nothing.
*/


Usage of the following in conjunction with BSD_setsockopt (3rd param) disables security:

#define SO_SSL_BYPASS_X509_VERIF                            0x01
/*!<
    Allow an opened SSL socket to bypass the X509 certificate 
    verification process.
    It is highly required NOT to use this socket option in production
    software applications. It is supported for debugging and testing 
    purposes.
    The option value should be casted to int type and it is handled
    as a boolean flag.
*/
```