### PR TITLE
Add missing data structure initialization

### DIFF
--- a/firmware/src/azutil.c
+++ b/firmware/src/azutil.c
@@ -126,10 +126,13 @@ void init_twin_data(twin_properties_t* twin_properties)
     twin_properties->reported_led_red   = LED_TWIN_NO_CHANGE;
     twin_properties->reported_led_blue  = LED_TWIN_NO_CHANGE;
     twin_properties->reported_led_green = LED_TWIN_NO_CHANGE;
+    twin_properties->debugLevel         = SEVERITY_INFO;
+    twin_properties->ip_address[0]      = '\0';
     twin_properties->app_property_1     = 0;
     twin_properties->app_property_2     = 0;
     twin_properties->app_property_3     = 0;
     twin_properties->app_property_4     = 0;
+    twin_properties->telemetry_disable_flag = 0;
 }
 
 /**************************************


### PR DESCRIPTION
## Purpose
A few members of twin_properties_t are not property initialized, resulting in picking up random numbers/data from memory.

## Does this introduce a breaking change?
[ ] No

## Pull Request Type
[ ] Bugfix

## How to Test
Provision SAM IoT, make sure "reported values" may not be expected value.
E.g. these properties should be reported with initial values.
- telemetry_disable_flag = 0
- debugLevel = SEVERITY_INFO (or 4)

## What to Check
Properties are reported with expected values

